### PR TITLE
Set trees directory relative to jar

### DIFF
--- a/src/main/java/genepi/haplogrep3/App.java
+++ b/src/main/java/genepi/haplogrep3/App.java
@@ -82,7 +82,7 @@ public class App implements Runnable {
 
 			configuration = Configuration.loadFromFile(configFile, parent);
 			treeRepository = new PhylotreeRepository();
-			treeRepository.loadFromConfiguration(configuration);
+			treeRepository.loadFromConfiguration(configuration, parent);
 
 			jobQueue = new JobQueue(configuration.getThreads());
 

--- a/src/main/java/genepi/haplogrep3/App.java
+++ b/src/main/java/genepi/haplogrep3/App.java
@@ -82,7 +82,7 @@ public class App implements Runnable {
 
 			configuration = Configuration.loadFromFile(configFile, parent);
 			treeRepository = new PhylotreeRepository();
-			treeRepository.loadFromConfiguration(configuration, parent);
+			treeRepository.loadFromConfiguration(configuration);
 
 			jobQueue = new JobQueue(configuration.getThreads());
 

--- a/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
+++ b/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
@@ -3,12 +3,9 @@ package genepi.haplogrep3.commands;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import genepi.haplogrep3.config.Configuration;
 import genepi.haplogrep3.haplogrep.io.HaplogroupClustering;
-import genepi.haplogrep3.model.Cluster;
 import genepi.haplogrep3.model.Phylotree;
 import genepi.haplogrep3.model.PhylotreeRepository;
 import picocli.CommandLine.Option;
@@ -59,7 +56,8 @@ public class ClusterHaplogroupsCommand extends AbstractCommand {
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
 		PhylotreeRepository repository = new PhylotreeRepository();
 		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
-		repository.loadFromConfiguration(configuration);
+		String parent = ".";
+		repository.loadFromConfiguration(configuration, parent);
 		return repository.getById(id);
 	}
 

--- a/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
+++ b/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
@@ -56,8 +56,7 @@ public class ClusterHaplogroupsCommand extends AbstractCommand {
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
 		PhylotreeRepository repository = new PhylotreeRepository();
 		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
-		String parent = ".";
-		repository.loadFromConfiguration(configuration, parent);
+		repository.loadFromConfiguration(configuration);
 		return repository.getById(id);
 	}
 

--- a/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
+++ b/src/main/java/genepi/haplogrep3/commands/ClusterHaplogroupsCommand.java
@@ -1,18 +1,15 @@
 package genepi.haplogrep3.commands;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import genepi.haplogrep3.config.Configuration;
+import genepi.haplogrep3.App;
 import genepi.haplogrep3.haplogrep.io.HaplogroupClustering;
 import genepi.haplogrep3.model.Phylotree;
 import genepi.haplogrep3.model.PhylotreeRepository;
 import picocli.CommandLine.Option;
 
 public class ClusterHaplogroupsCommand extends AbstractCommand {
-
-	public static String CONFIG_FILE = "haplogrep3.yaml";
 
 	@Option(names = { "--tree" }, description = "tree name", required = true)
 	String tree;
@@ -51,12 +48,10 @@ public class ClusterHaplogroupsCommand extends AbstractCommand {
 
 		return 0;
 
-	}
+	} 
 
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
-		PhylotreeRepository repository = new PhylotreeRepository();
-		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
-		repository.loadFromConfiguration(configuration);
+		PhylotreeRepository repository = App.getDefault().getTreeRepository();
 		return repository.getById(id);
 	}
 

--- a/src/main/java/genepi/haplogrep3/config/Configuration.java
+++ b/src/main/java/genepi/haplogrep3/config/Configuration.java
@@ -37,6 +37,8 @@ public class Configuration {
 
 	private List<NavbarLink> navbar = new Vector<NavbarLink>();
 
+	private String parent = "";
+
 	public Configuration() {
 
 	}
@@ -146,6 +148,8 @@ public class Configuration {
 		Configuration configuration = reader.read(Configuration.class);
 		reader.close();
 
+		configuration.parent = parent;
+
 		for (Dataset dataset : configuration.getExamples()) {
 			dataset.updateParent(parent);
 		}
@@ -163,4 +167,7 @@ public class Configuration {
 
 	}
 
+    public File getPluginsLocation() {
+		return new File(parent, "trees");
+    }
 }

--- a/src/main/java/genepi/haplogrep3/config/Configuration.java
+++ b/src/main/java/genepi/haplogrep3/config/Configuration.java
@@ -38,6 +38,8 @@ public class Configuration {
 	private List<NavbarLink> navbar = new Vector<NavbarLink>();
 
 	private String parent = "";
+	
+	private File configFile;
 
 	public Configuration() {
 
@@ -149,6 +151,7 @@ public class Configuration {
 		reader.close();
 
 		configuration.parent = parent;
+		configuration.configFile = file;
 
 		for (Dataset dataset : configuration.getExamples()) {
 			dataset.updateParent(parent);
@@ -159,7 +162,7 @@ public class Configuration {
 	}
 
 	public void save(File file) throws IOException {
-		YamlWriter writer = new YamlWriter(new FileWriter(file));
+		YamlWriter writer = new YamlWriter(new FileWriter(configFile));
 		writer.getConfig().setPropertyElementType(Configuration.class, "phylotrees", String.class);
 		writer.getConfig().setPropertyElementType(Configuration.class, "examples", Dataset.class);
 		writer.write(this);
@@ -170,4 +173,6 @@ public class Configuration {
     public File getPluginsLocation() {
 		return new File(parent, "trees");
     }
+   
+    
 }

--- a/src/main/java/genepi/haplogrep3/config/Configuration.java
+++ b/src/main/java/genepi/haplogrep3/config/Configuration.java
@@ -161,7 +161,7 @@ public class Configuration {
 
 	}
 
-	public void save(File file) throws IOException {
+	public void save() throws IOException {
 		YamlWriter writer = new YamlWriter(new FileWriter(configFile));
 		writer.getConfig().setPropertyElementType(Configuration.class, "phylotrees", String.class);
 		writer.getConfig().setPropertyElementType(Configuration.class, "examples", Dataset.class);

--- a/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
+++ b/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
@@ -79,7 +79,7 @@ public class PhylotreeRepository {
 
 		if (phylotree != null) {
 			configuration.getPhylotrees().add(id);
-			configuration.save(new File(App.CONFIG_FILENAME));
+			configuration.save();
 		}
 	}
 

--- a/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
+++ b/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
@@ -18,7 +18,7 @@ public class PhylotreeRepository {
 	private List<Phylotree> trees;
 
 	private List<String> categories = new Vector<String>();
-	
+
 	private boolean forceUpdate;
 
 	public static boolean FORCE_UPDATE = false;
@@ -27,12 +27,12 @@ public class PhylotreeRepository {
 		trees = new Vector<Phylotree>();
 	}
 
-	public synchronized void loadFromConfiguration(Configuration configuration)
+	public synchronized void loadFromConfiguration(Configuration configuration, String parent)
 			throws FileNotFoundException, IOException {
 
 		trees = new Vector<Phylotree>();
 
-		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate);
+		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, parent);
 
 		for (String id : configuration.getPhylotrees()) {
 
@@ -61,7 +61,9 @@ public class PhylotreeRepository {
 
 	public void install(String id, Configuration configuration) throws IOException {
 
-		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate);
+		String parent = ".";
+
+		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, parent);
 
 		Phylotree phylotree = null;
 
@@ -105,11 +107,11 @@ public class PhylotreeRepository {
 	public List<String> getCategories() {
 		return categories;
 	}
-	
-	public List<Phylotree> getByCategory(String category){
-		
+
+	public List<Phylotree> getByCategory(String category) {
+
 		// TODO: use data-structure with O(1), hashmap or so.
-		
+
 		List<Phylotree> result = new Vector<Phylotree>();
 		for (Phylotree tree : trees) {
 			if (tree.getCategory().equals(category)) {

--- a/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
+++ b/src/main/java/genepi/haplogrep3/model/PhylotreeRepository.java
@@ -27,12 +27,12 @@ public class PhylotreeRepository {
 		trees = new Vector<Phylotree>();
 	}
 
-	public synchronized void loadFromConfiguration(Configuration configuration, String parent)
+	public synchronized void loadFromConfiguration(Configuration configuration)
 			throws FileNotFoundException, IOException {
 
 		trees = new Vector<Phylotree>();
 
-		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, parent);
+		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, configuration.getPluginsLocation());
 
 		for (String id : configuration.getPhylotrees()) {
 
@@ -61,9 +61,7 @@ public class PhylotreeRepository {
 
 	public void install(String id, Configuration configuration) throws IOException {
 
-		String parent = ".";
-
-		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, parent);
+		PluginRepository repository = new PluginRepository(configuration.getRepositories(), forceUpdate, configuration.getPluginsLocation());
 
 		Phylotree phylotree = null;
 

--- a/src/main/java/genepi/haplogrep3/plugins/PluginRepository.java
+++ b/src/main/java/genepi/haplogrep3/plugins/PluginRepository.java
@@ -22,17 +22,13 @@ public class PluginRepository {
 
 	public static String LATEST_VERSION = null;
 
-	public File plugins_location = new File("trees");
+	public File pluginsLocation = new File("trees");
 
 	private List<List<Plugin>> repositories = new Vector<List<Plugin>>();
 
-	public PluginRepository(List<String> urls, boolean forceUpdate, String parent) throws IOException {
-
-		if (!parent.equals(".")) {
-			plugins_location = new File(FileUtil.path(parent, "trees"));
-		}
-
-		plugins_location.mkdirs();
+	public PluginRepository(List<String> urls, boolean forceUpdate, File pluginsLocation) throws IOException {
+		this.pluginsLocation = pluginsLocation;
+		pluginsLocation.mkdirs();
 
 		for (String url : urls) {
 			repositories.add(loadFromUrl(url, forceUpdate));
@@ -90,7 +86,7 @@ public class PluginRepository {
 
 		String filename = "tree.yaml";
 
-		File pluginPath = new File(plugins_location, FileUtil.path(id, release.getVersion()));
+		File pluginPath = new File(pluginsLocation, FileUtil.path(id, release.getVersion()));
 		InstalledPlugin plugin = new InstalledPlugin();
 		plugin.setRelease(release);
 		plugin.setPath(new File(pluginPath.getAbsolutePath(), filename));
@@ -132,7 +128,7 @@ public class PluginRepository {
 		File indexFile = null;
 
 		if (isHttpProtocol(url)) {
-			indexFile = new File(plugins_location, getNameForUrl(url) + ".yaml");
+			indexFile = new File(pluginsLocation, getNameForUrl(url) + ".yaml");
 			if (!indexFile.exists() || forceUpdate) {
 				download(url, indexFile);
 			}

--- a/src/main/java/genepi/haplogrep3/plugins/PluginRepository.java
+++ b/src/main/java/genepi/haplogrep3/plugins/PluginRepository.java
@@ -22,13 +22,17 @@ public class PluginRepository {
 
 	public static String LATEST_VERSION = null;
 
-	public static final File PLUGINS_LOCATION = new File("trees");
+	public File plugins_location = new File("trees");
 
 	private List<List<Plugin>> repositories = new Vector<List<Plugin>>();
 
-	public PluginRepository(List<String> urls, boolean forceUpdate) throws IOException {
+	public PluginRepository(List<String> urls, boolean forceUpdate, String parent) throws IOException {
 
-		PLUGINS_LOCATION.mkdirs();
+		if (!parent.equals(".")) {
+			plugins_location = new File(FileUtil.path(parent, "trees"));
+		}
+
+		plugins_location.mkdirs();
 
 		for (String url : urls) {
 			repositories.add(loadFromUrl(url, forceUpdate));
@@ -86,7 +90,7 @@ public class PluginRepository {
 
 		String filename = "tree.yaml";
 
-		File pluginPath = new File(PLUGINS_LOCATION, FileUtil.path(id, release.getVersion()));
+		File pluginPath = new File(plugins_location, FileUtil.path(id, release.getVersion()));
 		InstalledPlugin plugin = new InstalledPlugin();
 		plugin.setRelease(release);
 		plugin.setPath(new File(pluginPath.getAbsolutePath(), filename));
@@ -113,7 +117,7 @@ public class PluginRepository {
 		Files.copy(in, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
 	}
-	
+
 	protected void extract(File archive, File target) throws IOException {
 		new ZipFile(archive).extractAll(target.getAbsolutePath());
 
@@ -128,7 +132,7 @@ public class PluginRepository {
 		File indexFile = null;
 
 		if (isHttpProtocol(url)) {
-			indexFile = new File(PLUGINS_LOCATION, getNameForUrl(url) + ".yaml");
+			indexFile = new File(plugins_location, getNameForUrl(url) + ".yaml");
 			if (!indexFile.exists() || forceUpdate) {
 				download(url, indexFile);
 			}

--- a/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
+++ b/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
@@ -29,8 +29,7 @@ public class ClassificationTaskTest {
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
 		PhylotreeRepository repository = new PhylotreeRepository();
 		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
-		String parent = ".";
-		repository.loadFromConfiguration(configuration, parent);
+		repository.loadFromConfiguration(configuration);
 		return repository.getById(id);
 	}
 

--- a/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
+++ b/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
@@ -29,7 +29,8 @@ public class ClassificationTaskTest {
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
 		PhylotreeRepository repository = new PhylotreeRepository();
 		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
-		repository.loadFromConfiguration(configuration);
+		String parent = ".";
+		repository.loadFromConfiguration(configuration, parent);
 		return repository.getById(id);
 	}
 
@@ -223,7 +224,7 @@ public class ClassificationTaskTest {
 		assertEquals("2", task.getCounterByLabel("Variant Call Rate < 90%").getValue());
 		assertEquals("1", task.getCounterByLabel("Strand Flips").getValue());
 		assertEquals("3", task.getCounterByLabel("Monomorphic Variants").getValue());
-		
+
 		assertEquals(StatisticCounterType.WARNING, task.getCounterByLabel("Strand Flips").getType());
 		assertEquals(StatisticCounterType.INFO, task.getCounterByLabel("Samples").getType());
 

--- a/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
+++ b/src/test/java/genepi/haplogrep3/tasks/ClassificationTaskTest.java
@@ -28,12 +28,12 @@ public class ClassificationTaskTest {
 
 	public Phylotree loadPhylotree(String id) throws FileNotFoundException, IOException {
 		PhylotreeRepository repository = new PhylotreeRepository();
-		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), "");
+		Configuration configuration = Configuration.loadFromFile(new File(CONFIG_FILE), ".");
 		repository.loadFromConfiguration(configuration);
 		return repository.getById(id);
 	}
 
-	@Test
+	@Test 
 	public void testWithHsd() throws Exception {
 
 		Phylotree phylotree = loadPhylotree(PHYLOTREE);
@@ -134,7 +134,7 @@ public class ClassificationTaskTest {
 
 		String tree = "phylotree-fu-rcrs@1.0";
 
-		Phylotree phylotree = loadPhylotree(tree);
+		Phylotree phylotree = loadPhylotree(tree); 
 
 		List<File> files = new ArrayList<File>();
 		files.add(new File("test-data/fasta/L3i2_1.fasta"));


### PR DESCRIPTION
The idea of this pull request is to set the trees directory relative to the jar file and identical to the configuration file. The reason is that for e.g. Nextflow the trees are currently always installed in the local working directory. 